### PR TITLE
Z-probe offset zero, README additions, rename PINDA temp smoothing #defines

### DIFF
--- a/Marlin/example_configurations/Prusa/MK3/Configuration.h
+++ b/Marlin/example_configurations/Prusa/MK3/Configuration.h
@@ -329,9 +329,9 @@
   #define TEMP_PINDA_PIN  3
   #define TEMP_SENSOR_PINDA 1
 
-  #define PINDA_SMOOTHING
-  #if ENABLED(PINDA_SMOOTHING)
-    #define PINDA_SMOOTHING_DIVISOR_LOG2 6
+  #define PINDA_TEMP_SMOOTHING
+  #if ENABLED(PINDA_TEMP_SMOOTHING)
+    #define PINDA_TEMP_SMOOTHING_DIV_LOG2 6
   #endif
 #endif
 
@@ -803,8 +803,8 @@
  *    (0,0)
  */
 #define X_PROBE_OFFSET_FROM_EXTRUDER 23  // X offset: -left  +right  [of the nozzle]
-#define Y_PROBE_OFFSET_FROM_EXTRUDER 5  // Y offset: -front +behind [the nozzle]
-#define Z_PROBE_OFFSET_FROM_EXTRUDER -0.4   // Z offset: -below +above  [the nozzle]
+#define Y_PROBE_OFFSET_FROM_EXTRUDER 5   // Y offset: -front +behind [the nozzle]
+#define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle]
 
 // Certain types of probes need to stay away from edges
 #define MIN_PROBE_EDGE 10

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -135,7 +135,7 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 #if HAS_TEMP_PINDA
   float Temperature::current_temperature_pinda = 0.0;
   int16_t Temperature::current_temperature_pinda_raw = 0;
-  #if ENABLED(PINDA_SMOOTHING)
+  #if ENABLED(PINDA_TEMP_SMOOTHING)
     uint16_t Temperature::current_temperature_pinda_raw_remainder = 0;
     bool Temperature::first_sample = true;
   #endif
@@ -1693,8 +1693,8 @@ void Temperature::set_current_temp_raw() {
     current_temperature_chamber_raw = raw_temp_chamber_value;
   #endif
   #if HAS_TEMP_PINDA
-    #if ENABLED(PINDA_SMOOTHING) && (PINDA_SMOOTHING_DIVISOR_LOG2 > 0)
-      const uint16_t remainder_mask = (1 << PINDA_SMOOTHING_DIVISOR_LOG2)-1;
+    #if ENABLED(PINDA_TEMP_SMOOTHING) && (PINDA_TEMP_SMOOTHING_DIV_LOG2 > 0)
+      const uint16_t remainder_mask = (1 << PINDA_TEMP_SMOOTHING_DIV_LOG2)-1;
 
       if (first_sample) {
         current_temperature_pinda_raw = raw_temp_pinda_value;
@@ -1706,7 +1706,7 @@ void Temperature::set_current_temp_raw() {
           + raw_temp_pinda_value 
           + current_temperature_pinda_raw_remainder;
 
-        current_temperature_pinda_raw = (int16_t)(full_precision >> PINDA_SMOOTHING_DIVISOR_LOG2);
+        current_temperature_pinda_raw = (int16_t)(full_precision >> PINDA_TEMP_SMOOTHING_DIV_LOG2);
         current_temperature_pinda_raw_remainder = (uint16_t)(full_precision & remainder_mask);
       }
     #else

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -275,7 +275,7 @@ class Temperature {
       static uint16_t raw_temp_pinda_value;
       static float current_temperature_pinda;
       static int16_t current_temperature_pinda_raw;
-      #if ENABLED(PINDA_SMOOTHING)
+      #if ENABLED(PINDA_TEMP_SMOOTHING)
         static bool first_sample;
         static uint16_t current_temperature_pinda_raw_remainder;
       #endif


### PR DESCRIPTION
* Set probe Z-offset to zero. This is a more conservative starting point when using the babystep offset feature, and more closely mimics the behavior Prusa users will expect.
* Renamed PINDA smoothing defines to reflect that we're smoothing the PINDA temperature, not the PINDA probing.
* Updated the README with project goals, non-goals, more detail about benefits of the firmware.
* Updated the change list in the README to reflect recent check-ins