### PR TITLE
Correct configuration for MK3S filament runout sensor (still disabled)

### DIFF
--- a/Marlin/example_configurations/Prusa/MK3/Configuration.h
+++ b/Marlin/example_configurations/Prusa/MK3/Configuration.h
@@ -955,8 +955,9 @@
  */
 //#define FILAMENT_RUNOUT_SENSOR
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #define FIL_RUNOUT_PIN 62   // Valid for newer Prusa MK3S filament sensor
   #define NUM_RUNOUT_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
-  #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
+  #define FIL_RUNOUT_INVERTING true  // MK3S sensor asserts high/true on runout
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 #endif


### PR DESCRIPTION
Add correct configuration for MK3S filament runout sensor. I am leaving the feature disabled for now, as I don't have a sensor to test it with yet.