### PR TITLE
Move print head to X0/Y0/Z0.15 after mesh bed leveling

### DIFF
--- a/Marlin/example_configurations/Prusa/MK3/Configuration.h
+++ b/Marlin/example_configurations/Prusa/MK3/Configuration.h
@@ -1145,7 +1145,7 @@
  * Commands to execute at the end of G29 probing.
  * Useful to retract or move the Z probe out of the way.
  */
-//#define Z_PROBE_END_SCRIPT "G1 Z10 F12000\nG1 X15 Y330\nG1 Z0.5\nG1 Z10"
+#define Z_PROBE_END_SCRIPT "G1 X0.0 Y0.0 Z0.15 F4000"
 
 
 // @section homing


### PR DESCRIPTION
Enable Z_PROBE_END_SCRIPT feature to mimick Prusa feature of moving print head to X0/Y0/Z0.15 after mesh leveling.

Implementation of feature #18 