### PR TITLE
Basic implementation of fan tachometer readings. Use M198 to retrieve

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -866,6 +866,25 @@
 #define HAS_FAN2 (PIN_EXISTS(FAN2) && CONTROLLER_FAN_PIN != FAN2_PIN && E0_AUTO_FAN_PIN != FAN2_PIN && E1_AUTO_FAN_PIN != FAN2_PIN && E2_AUTO_FAN_PIN != FAN2_PIN && E3_AUTO_FAN_PIN != FAN2_PIN)
 #define HAS_CONTROLLER_FAN (PIN_EXISTS(CONTROLLER_FAN))
 
+// Fan tachometers
+#define HAS_TACH_E0 (PIN_EXISTS(TACH_E0))
+#define HAS_TACH_E1 (PIN_EXISTS(TACH_E1))
+#define HAS_TACH_0  (PIN_EXISTS(TACH_0))
+#define HAS_TACH_1  (PIN_EXISTS(TACH_1))
+
+#ifndef TACH_E0_PPR
+  #define TACH_E0_PPR 2
+#endif  
+#ifndef TACH_E1_PPR
+  #define TACH_E1_PPR 2
+#endif  
+#ifndef TACH_0_PPR
+  #define TACH_0_PPR 2
+#endif  
+#ifndef TACH_1_PPR
+  #define TACH_1_PPR 2
+#endif  
+
 // Servos
 #define HAS_SERVO_0 (PIN_EXISTS(SERVO0))
 #define HAS_SERVO_1 (PIN_EXISTS(SERVO1))

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -247,6 +247,49 @@
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
 /**
+ * Fan Tachometer Readings
+ */
+//#define FANTACH
+#if ENABLED(FANTACH)
+  /**
+   * Enable and define pins for extruder and print fan tachometers. 
+   */
+  //#define TACH_E0_PIN 79
+  //#define TACH_E1_PIN -1
+  //#define TACH_0_PIN 80
+  //#define TACH_1_PIN -1
+
+  /**
+   * Define the number of tachometer pulses for each rotation of the fan. 
+   * This varies depending on the fan. Fans typically have 2 or 3 hall-effect 
+   * sensors, leading to 2 or 3 pulses per rotation. value for a fan with a 
+   * known approximate RPM value, is set this to some reasonable value, and then
+   * scale it based on the reading you get.
+   */
+  #define TACH_E0_PPR 2
+  #define TACH_E1_PPR 2
+  #define TACH_0_PPR 2
+  #define TACH_1_PPR 2
+
+  /**
+   * Enable pull-up resistor for extruder fan tachometers
+   */
+  //#define TACH_E0_PULLUP
+  //#define TACH_E1_PULLUP
+  //#define TACH_0_PULLUP
+  //#define TACH_1_PULLUP
+
+  /**
+   * Uncomment this if this if all enabled fan tachometer pins support interrupts 
+   * (only normal interrupts, not pin-change interrupts are supported)
+   */
+  //#define FANTACH_INTERRUPT
+
+  // Defines amount of time before fan tach counts are aggregated into an approximate RPM value
+  #define FANTACH_SAMPLE_WINDOW_MS    1000
+#endif
+
+/**
  * Part-Cooling Fan Multiplexer
  *
  * This feature allows you to digitally multiplex the fan output.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -156,6 +156,7 @@
  * M165 - Set the mix for a mixing extruder wuth parameters ABCDHI. (Requires MIXING_EXTRUDER and DIRECT_MIXING_IN_G1)
  * M190 - Sxxx Wait for bed current temp to reach target temp. ** Waits only when heating! **
  *        Rxxx Wait for bed current temp to reach target temp. ** Waits for heating or cooling. **
+ * M198   Read fan tachometer (RPM) values. Requires FANTACH.
  * M199 - Wait for temperature sensitive bed level sensor to reach target temperature. (Requires PINDA_THERMISTOR)
  * M200 - Set filament diameter, D<diameter>, setting E axis units to cubic. (Use S0 to revert to linear units.)
  * M201 - Set max acceleration in units/s^2 for print moves: "M201 X<accel> Y<accel> Z<accel> E<accel>"
@@ -340,6 +341,10 @@
 
 #if ENABLED(I2C_POSITION_ENCODERS)
   #include "I2CPositionEncoder.h"
+#endif
+
+#if ENABLED(FANTACH)
+  #include "fantachs.h"
 #endif
 
 #if ENABLED(M100_FREE_MEMORY_WATCHER)
@@ -9449,6 +9454,12 @@ inline void gcode_M121() { endstops.enable_globally(false); }
 
 #endif // HAS_COLOR_LEDS
 
+#if ENABLED(FANTACH)
+  inline void gcode_M198() {
+    fantachs.printTachRpms();
+  }
+#endif
+
 #if ENABLED(PINDA_THERMISTOR)
 
   /**
@@ -13016,6 +13027,10 @@ void process_parsed_command() {
         #endif
       #endif
 
+      #if ENABLED(FANTACH)
+        case 198: gcode_M198(); break;                              // M129: Report Fan Tachometer Values
+      #endif
+
       #if ENABLED(PINDA_THERMISTOR)
         case 199: gcode_M199(); break;                            // M119 -  Wait for temperature sensitive bed level sensor to reach target temperature. 
       #endif
@@ -15075,6 +15090,10 @@ void idle(
       #endif
     }
   #endif
+
+  #if ENABLED(FANTACH)
+    fantachs.updateRpm();
+  #endif
 }
 
 /**
@@ -15244,6 +15263,10 @@ void setup() {
   stepper.init();           // Init stepper. This enables interrupts!
 
   servo_init();             // Initialize all servos, stow servo probe
+
+  #if ENABLED(FANTACH)
+    fantachs.init();        // Initialize fan tachometer readings
+  #endif
 
   #if HAS_PHOTOGRAPH
     OUT_WRITE(PHOTOGRAPH_PIN, LOW);

--- a/Marlin/example_configurations/Prusa/MK3/Configuration_adv.h
+++ b/Marlin/example_configurations/Prusa/MK3/Configuration_adv.h
@@ -268,6 +268,48 @@
  */
 #define FAN1_PIN -1
 
+/**
+ * Fan Tachometer Readings
+ */
+#define FANTACH
+#if ENABLED(FANTACH)
+  /**
+   * Enable and define pins for extruder and print fan tachometers. 
+   */
+  #define TACH_E0_PIN 79
+  //#define TACH_E1_PIN -1
+  #define TACH_0_PIN 80
+  //#define TACH_1_PIN -1
+
+  /**
+   * Define the number of tachometer pulses for each rotation of the fan. 
+   * This varies depending on the fan. Fans typically have 2 or 3 hall-effect 
+   * sensors, leading to 2 or 3 pulses per rotation. value for a fan with a 
+   * known approximate RPM value, is set this to some reasonable value, and then
+   * scale it based on the reading you get.
+   */
+  #define TACH_E0_PPR 2
+  //#define TACH_E1_PPR 2
+  #define TACH_0_PPR 2
+  //#define TACH_1_PPR 2
+
+  /**
+   * Enable pull-up resistor for extruder fan tachometers
+   */
+  //#define TACH_E0_PULLUP
+  //#define TACH_E1_PULLUP
+  //#define TACH_0_PULLUP
+  //#define TACH_1_PULLUP
+
+  /**
+   * Uncomment this if this if all enabled fan tachometer pins support interrupts 
+   * (only normal interrupts, not pin-change interrupts are supported)
+   */
+  #define FANTACH_INTERRUPT
+
+  // Defines amount of time before fan tach counts are aggregated into an approximate RPM value
+  #define FANTACH_SAMPLE_WINDOW_MS    1000
+#endif
 
 /**
  * Part-Cooling Fan Multiplexer

--- a/Marlin/fantachs.cpp
+++ b/Marlin/fantachs.cpp
@@ -1,0 +1,272 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * fantach.cpp - manages tachometer readings from fans
+ */
+
+#include "MarlinConfig.h"
+
+#if ENABLED(FANTACH)
+
+#include "fantachs.h"
+
+
+/**
+ * Pin definition macros do not correctly support all interrupt capable pins on the 
+ * ATMEGA2560. We redefine some macros for that here.
+ */
+#if defined(__AVR_ATmega2560__)
+
+  /**
+   * Arduino has its own interrupt numbering scheme, that is somewhat inconsistent across processors and 
+   * doesn't match the numbers in the processor data sheet. For the ATMEGA2560, here is the mapping.
+   *
+   *  ATMEGA2560 |  Arduino  | ATMEGA2560 |  Arduino  |
+   *  Port/Pin # |  Pin #    |   INT #    |   INT #   |
+   *  -------------------------------------------------
+   *   PD0 / 43        21          0            2
+   *   PD1 / 44        20          1            3
+   *   PD2 / 45        19          2            4
+   *   PD3 / 46        18          3            5
+   *   PE4 / 6          2          4            0
+   *   PE5 / 7          3          5            1
+   *   PE6 / 8         79          6            6
+   *   PE7 / 9         80          7            7
+   */
+  #undef digitalPinToInterrupt
+  #define digitalPinToInterrupt(p) ((p) == 2 ? 0 : ((p) == 3 ? 1 : ((p) >= 18 && (p) <= 21 ? 23 - (p) : ((p) >= 79 && (p) <= 80 ? (p) - 73 :NOT_AN_INTERRUPT))))
+
+#endif // __AVR_ATmega2560__
+
+
+millis_t FanTachs::last_rpm_update_ms = 0;
+millis_t FanTachs::last_rpm_interval_ms = 0;
+
+#if HAS_TACH_E0
+  uint16_t FanTachs::count_e0 = 0;
+  uint16_t FanTachs::rpm_e0 = 0;
+#endif
+
+#if HAS_TACH_E1
+  uint16_t FanTachs::count_e1 = 0;
+  uint16_t FanTachs::rpm_e1 = 0;
+#endif
+
+#if HAS_TACH_0
+  uint16_t FanTachs::count_0 = 0;
+  uint16_t FanTachs::rpm_0 = 0;
+#endif
+
+#if HAS_TACH_1
+  uint16_t FanTachs::count_1 = 0;
+  uint16_t FanTachs::rpm_1 = 0;
+#endif
+
+#if DISABLED(FANTACH_INTERRUPT)
+  #if HAS_TACH_E0
+    uint8_t  FanTachs::state_e0 = 0;
+  #endif
+
+  #if HAS_TACH_E1
+    uint8_t  FanTachs::state_e1 = 0;
+  #endif
+
+  #if HAS_TACH_0
+    uint8_t  FanTachs::state_0 = 0;
+  #endif
+
+  #if HAS_TACH_1
+    uint8_t  FanTachs::state_1 = 0;
+  #endif
+#endif
+
+void FanTachs::init()
+{
+  last_rpm_update_ms = millis();
+
+  #if HAS_TACH_E0 && defined(TACH_E0_PULLUP)
+    SET_INPUT_PULLUP(TACH_E0_PIN);
+  #endif
+  #if HAS_TACH_E1 && defined(TACH_E1_PULLUP)
+    SET_INPUT_PULLUP(TACH_E1_PIN);
+  #endif
+  #if HAS_TACH_0 && defined(TACH_0_PULLUP)
+    SET_INPUT_PULLUP(TACH_0_PIN);
+  #endif
+  #if HAS_TACH_1 && defined(TACH_1_PULLUP)
+    SET_INPUT_PULLUP(TACH_1_PIN);
+  #endif
+
+#if ENABLED(FANTACH_INTERRUPT)
+  #if HAS_TACH_E0
+    static_assert(digitalPinToInterrupt(TACH_E0_PIN) != NOT_AN_INTERRUPT, "TACH_E0_PIN is not interrupt-capable");
+    attachInterrupt(digitalPinToInterrupt(TACH_E0_PIN), FanTachs::isr_e0, FALLING); 
+  #endif
+
+  #if HAS_TACH_E1
+    static_assert(digitalPinToInterrupt(TACH_E1_PIN) != NOT_AN_INTERRUPT, "TACH_E1_PIN is not interrupt-capable");
+    attachInterrupt(digitalPinToInterrupt(TACH_E1_PIN), FanTachs::isr_e1, FALLING); 
+  #endif
+
+  #if HAS_TACH_0
+    static_assert(digitalPinToInterrupt(TACH_0_PIN) != NOT_AN_INTERRUPT, "TACH_0_PIN is not interrupt-capable");
+    attachInterrupt(digitalPinToInterrupt(TACH_0_PIN), FanTachs::isr_0, FALLING); 
+  #endif
+
+  #if HAS_TACH_1
+    static_assert(digitalPinToInterrupt(TACH_1_PIN) != NOT_AN_INTERRUPT, "TACH_1_PIN is not interrupt-capable");
+    attachInterrupt(digitalPinToInterrupt(TACH_1_PIN), FanTachs::isr_1, FALLING); 
+  #endif
+#endif
+}
+
+#if ENABLED(FANTACH_INTERRUPT)
+  #if HAS_TACH_E0
+    void FanTachs::isr_e0() {
+      ++count_e0;
+    }
+  #endif
+
+  #if HAS_TACH_E1
+    void FanTachs::isr_e1() {
+      ++count_e1;
+    }
+  #endif
+
+  #if HAS_TACH_0
+    void FanTachs::isr_0() {
+        ++count_0;
+    }
+  #endif
+
+  #if HAS_TACH_1
+    void FanTachs::isr_1() {
+      ++count_1;
+    }
+  #endif
+#endif
+
+#if DISABLED(FANTACH_INTERRUPT)
+  void FanTachs::updateCounts() {
+    uint8_t pinstate;
+
+    #if HAS_TACH_E0
+      pinstate = READ(TACH_E0_PIN);
+      if (!pinstate && state_e0) { // Falling edge
+        ++count_e0;
+      }
+      state_e0 = pinstate;
+    #endif
+    
+    #if HAS_TACH_E1
+      pinstate = READ(TACH_E1_PIN);
+      if (!pinstate && state_e1) { // Falling edge
+        ++count_e1;
+      }
+      state_e1 = pinstate;
+    #endif
+
+    #if HAS_TACH_0
+      pinstate = READ(TACH_0_PIN);
+      if (!pinstate && state_0) { // Falling edge
+        ++count_0;
+      }
+      state_0 = pinstate;
+    #endif
+
+    #if HAS_TACH_1
+      pinstate = READ(TACH_1_PIN);
+      if (!pinstate && state_1) { // Falling edge
+        ++count_1;
+      }
+      state_1 = pinstate;
+    #endif
+  }
+#endif
+
+void FanTachs::updateRpm()
+{
+  const millis_t now = millis();
+  const millis_t elapsed_ms =  now - last_rpm_update_ms;
+    
+  if (elapsed_ms > FANTACH_SAMPLE_WINDOW_MS)
+  {
+    last_rpm_update_ms = now;
+
+    // Capture and reset count values with interrupts disabled so updateCounts doesn't run concurrently.
+    // Do minimal work with interrupts disabled
+    CRITICAL_SECTION_START;
+      #if HAS_TACH_E0
+        const uint16_t tmp_count_e0 = count_e0;
+        count_e0 = 0;
+      #endif
+      #if HAS_TACH_E1
+        const uint16_t tmp_count_e1 = count_e1;
+        count_e1 = 0;
+      #endif
+      #if HAS_TACH_0
+        const uint16_t tmp_count_0 = count_0;
+        count_0 = 0;
+      #endif
+      #if HAS_TACH_1
+        const uint16_t tmp_count_1 = count_1;
+        count_1 = 0;
+      #endif
+    CRITICAL_SECTION_END;
+
+    #if HAS_TACH_E0
+      rpm_e0 = (uint16_t)((uint32_t)tmp_count_e0 * 60 * 1000 / TACH_E0_PPR / elapsed_ms);
+    #endif
+    #if HAS_TACH_E1
+      rpm_e1 = (uint16_t)((uint32_t)tmp_count_e1 * 60 * 1000 / TACH_E1_PPR / elapsed_ms);
+    #endif
+    #if HAS_TACH_0
+      rpm_0 = (uint16_t)((uint32_t)tmp_count_0 * 60 * 1000 / TACH_0_PPR / elapsed_ms);
+    #endif
+    #if HAS_TACH_1
+      rpm_1 = (uint16_t)((uint32_t)tmp_count_1 * 60 * 1000 / TACH_1_PPR / elapsed_ms);
+    #endif
+
+    last_rpm_interval_ms = elapsed_ms;
+  }
+}
+
+void FanTachs::printTachRpms()
+{
+  #if HAS_TACH_E0
+    SERIAL_PROTOCOLPAIR(" E0: ", rpm_e0);
+  #endif
+  #if HAS_TACH_E1
+    SERIAL_PROTOCOLPAIR(" E1: ", rpm_e1);
+  #endif
+  #if HAS_TACH_0
+    SERIAL_PROTOCOLPAIR(" 0: ", rpm_0);
+  #endif
+  #if HAS_TACH_1
+    SERIAL_PROTOCOLPAIR(" 1: ", rpm_1);
+  #endif
+  SERIAL_EOL();
+}
+
+
+#endif  // FANTACH

--- a/Marlin/fantachs.h
+++ b/Marlin/fantachs.h
@@ -1,0 +1,133 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * fantach.h - Captures ane makes available tachometer readings from tach-enabled fans.
+ */
+
+#pragma once
+
+#include "MarlinConfig.h"
+
+class FanTachs {
+private:
+
+  #if HAS_TACH_E0
+    static uint16_t count_e0;
+    static uint16_t rpm_e0;
+  #endif
+
+  #if HAS_TACH_E1
+    static uint16_t count_e1;
+    static uint16_t rpm_e1;
+  #endif
+
+  #if HAS_TACH_0
+    static uint16_t count_0;
+    static uint16_t rpm_0;
+  #endif
+
+  #if HAS_TACH_1
+    static uint16_t count_1;
+    static uint16_t rpm_1;
+  #endif
+
+  static millis_t last_rpm_update_ms;
+  static millis_t last_rpm_interval_ms;
+
+#if ENABLED(FANTACH_INTERRUPT)
+  #if HAS_TACH_E0
+    static void isr_e0();
+  #endif
+
+  #if HAS_TACH_E1
+    static void isr_e1();
+  #endif
+
+  #if HAS_TACH_0
+    static void isr_0();
+  #endif
+
+  #if HAS_TACH_1
+    static void isr_1();
+  #endif
+#else
+  #if HAS_TACH_E0
+    static uint8_t  state_e0;
+  #endif
+
+  #if HAS_TACH_E1
+    static uint8_t  state_e1;
+  #endif
+
+  #if HAS_TACH_0
+    static uint8_t  state_0;
+  #endif
+
+  #if HAS_TACH_1
+    static uint8_t  state_1;
+  #endif
+#endif
+
+public:
+  FanTachs() { };
+
+  /**
+   * Initialize the fan tachometer pins and interrupt handlers
+   */
+  static void init();
+
+  /**
+   * Periodic call to check for tachometer pins state changes and update the associated counts.
+   * Called from either temperature ISR (not used when ISR is in use).
+   */
+#if DISABLED(FANTACH_INTERRUPT)
+  static void updateCounts();
+#endif
+
+  /**
+   * Called periodically from idle to capture tachometer count and turn it into an RPM value.
+   */
+  static void updateRpm();
+
+  /**
+   * These methods provide estimates rotations-per-minute (RPM) value for each fan.
+   */
+#if HAS_TACH_E0
+  FORCE_INLINE static uint16_t rpmFanE0() { return rpm_e0; }
+#endif
+#if HAS_TACH_E1
+  FORCE_INLINE static uint16_t rpmFanE1() { return rpm_e1; }
+#endif
+#if HAS_TACH_0
+  FORCE_INLINE static uint16_t rpmFan0() { return rpm_0; }
+#endif
+#if HAS_TACH_1
+  FORCE_INLINE static uint16_t rpmFan1() { return rpm_1; }
+#endif
+
+  // Serial print fan tachometer values
+  static void printTachRpms();
+};
+
+extern FanTachs fantachs;
+

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -411,6 +411,30 @@
   #define CONTROLLER_FAN_PIN  -1
 #endif
 
+#if DISABLED(FANTACH)
+  #undef TACH_E0_PIN
+  #define TACH_E0_PIN    -1
+  #undef TACH_E1_PIN
+  #define TACH_E1_PIN    -1
+  #undef TACH_0_PIN
+  #define TACH_0_PIN    -1
+  #undef TACH_1_PIN
+  #define TACH_1_PIN    -1
+#else  
+  #ifndef TACH_E0_PIN
+    #define TACH_E0_PIN -1
+  #endif
+  #ifndef TACH_E1_PIN
+    #define TACH_E1_PIN -1
+  #endif
+  #ifndef TACH_0_PIN
+    #define TACH_0_PIN -1
+  #endif
+  #ifndef TACH_1_PIN
+    #define TACH_1_PIN -1
+  #endif
+#endif
+
 #ifndef FANMUX0_PIN
   #define FANMUX0_PIN -1
 #endif

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -34,6 +34,10 @@
 #include "delay.h"
 #include "endstops.h"
 
+#if ENABLED(FANTACH)
+  #include "fantachs.h"
+#endif
+
 #if ENABLED(HEATER_0_USES_MAX6675)
   #include "MarlinSPI.h"
 #endif
@@ -2360,6 +2364,11 @@ void Temperature::isr() {
 
   // Poll endstops state, if required
   endstops.poll();
+
+  // Poll fantach state, if required
+  #if ENABLED(FANTACH) && DISABLED(FANTACH_INTERRUPT)
+    fantachs.updateCounts();
+  #endif
 
   // Periodically call the planner timer
   planner.tick();


### PR DESCRIPTION
### Description
This pull request is a basic implementation of fan tachometer readings. A new section was added to Configuration_Adv.h (see "FANTACH") to enable and configure this feature. When enabled, it allows the firmware to perform fan tachometer (RPM) readings and makes this information available via a new g-code, M198.

The intent is to extend this feature to also check for correct extruder fan functioning for any extruder fans that are enabled by the AUTO_FAN feature.

### Benefits

This feature is a precursor to an additional safety check for the hot-end, and also will support a future pre-print "fans check" g-code that can serve as a way to validate both print and extruder fans are operating correctly.
